### PR TITLE
Support a root prefix when scanning directory

### DIFF
--- a/lib/tar_merger.ex
+++ b/lib/tar_merger.ex
@@ -32,7 +32,7 @@ defmodule TarMerger do
     TarMerger.mkfs_squashfs("test.sqfs", system)
   end
 
-  defdelegate scan_directory(path), to: FSReader
+  defdelegate scan_directory(path, root \\ "/"), to: FSReader
 
   defdelegate read_tar(path), to: TarReader
   defdelegate write_tar(path, entries), to: TarWriter
@@ -46,7 +46,7 @@ defmodule TarMerger do
   @spec merge([entries()]) :: entries()
   def merge(entries_list) when is_list(entries_list) do
     entries_list
-    |> Enum.concat()
+    |> List.flatten()
     |> Enum.uniq_by(fn entry -> entry.path end)
   end
 


### PR DESCRIPTION
Allows us to scan a host directory which may not be the end directory structure, but still specify the merged directory root it should be. For example, given the conditions below

```
# host dir to scan

some_dir
├── file1
└── dir2
    ├── file2
    ├── file3
    └── file4

# desired output

dir2
├── file2
├── file3
└── file4
```

We can now run this to achieve the expected results:

```elixir
TarMerger.scan_directory("some_dir/dir2", "dir2")
```